### PR TITLE
Updating Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
-          files: test-results/*.xml
+          junit_files: test-results/*.xml
       #- name: Deploy to GH pages
       #  if: startsWith(github.ref, 'refs/tags/v')
       # uses: JamesIves/github-pages-deploy-action@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 on: push
 name: Build Angular Application
+permissions:
+  contents: read
+  issues: read
+  checks: write
 jobs:
   build:
     if: github.ref != 'refs/heads/master'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,7 @@ jobs:
           artifacts: "dist/angular-githubaction/*"
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@v1
+        uses: EnricoMi/publish-unit-test-result-action@v2
         if: always()
         with:
           files: test-results/*.xml


### PR DESCRIPTION
* added permissions to address warning in EnricoMi/publish-unit-test-result-action
* updated EnricoMi/publish-unit-test-result-action to v2
* switched from the deprecated `file` to `junit_file` to address warning in EnricoMi/publish-unit-test-result-action